### PR TITLE
🔒 [security fix] Unsafe usage of ast.literal_eval on external input

### DIFF
--- a/debug/verify_vulnerability.py
+++ b/debug/verify_vulnerability.py
@@ -1,0 +1,67 @@
+import json
+import re
+
+# Simulate the modified parse_tags in generic_functions.py
+def parse_tags(tags):
+    """Safe parser for OSM tags in JSON or HSTORE-like format."""
+    if not tags or tags == "nan":
+        return {}
+
+    # Limit string length to prevent resource exhaustion
+    if len(tags) > 100000:
+        return {}
+
+    # 1. Try JSON format
+    try:
+        return json.loads(tags)
+    except (json.JSONDecodeError, RecursionError):
+        pass
+
+    # 2. Try HSTORE-like format: "key"=>"value", "key2"=>"value2"
+    d = {}
+    try:
+        # This regex matches "key"=>"value" pairs, handles backslash-escaped quotes
+        pattern = r'"((?:\\.|[^"\\])*)"\s*=>\s*"((?:\\.|[^"\\])*)"'
+        for match in re.finditer(pattern, tags):
+            key = match.group(1).replace('\\"', '"').replace('\\\\', '\\')
+            value = match.group(2).replace('\\"', '"').replace('\\\\', '\\')
+            d[key] = value
+        return d
+    except Exception:
+        return {}
+
+def test_vulnerability():
+    print("Testing parse_tags with EXTREMELY deeply nested input (RecursionError)...")
+    # Using 100,000 but it will be caught by length limit first if I am not careful
+    # Length limit is 100,000. So let's use 40,000 pairs of brackets.
+    deep_input = "[" * 40000 + "1" + "]" * 40000
+    print(f"Input length: {len(deep_input)}")
+    try:
+        result = parse_tags(deep_input)
+        print(f"Result for deep input length: {len(str(result)) if result else 0}")
+    except Exception as e:
+        print(f"Caught exception: {type(e).__name__}: {e}")
+
+    print("\nTesting parse_tags with very long input (Length Limit)...")
+    long_input = '"key"=>"value", ' * 10000 # 16 * 10000 = 160,000
+    print(f"Input length: {len(long_input)}")
+    try:
+        result = parse_tags(long_input)
+        print(f"Result for long input (should be {{}}): {result}")
+    except Exception as e:
+        print(f"Caught exception: {type(e).__name__}: {e}")
+
+    print("\nTesting with HSTORE-like input...")
+    hstore_input = '"width"=>"10", "maxspeed"=>"50", "name"=>"O\'\\\"Reilly"'
+    print(f"Input: {hstore_input}")
+    result = parse_tags(hstore_input)
+    print(f"Result for HSTORE: {result}")
+
+    print("\nTesting with JSON input...")
+    json_input = '{"width": "10", "maxspeed": "50"}'
+    print(f"Input: {json_input}")
+    result = parse_tags(json_input)
+    print(f"Result for JSON: {result}")
+
+if __name__ == "__main__":
+    test_vulnerability()

--- a/headless_sidewalkreator/generic_functions.py
+++ b/headless_sidewalkreator/generic_functions.py
@@ -282,7 +282,8 @@ def polygonize_lines_gdf(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     return gdf_poly
 
 
-import ast
+import json
+import re
 import pandas as pd
 
 from shapely.ops import split, substring
@@ -1971,11 +1972,31 @@ def data_clean_gdf(
 
     # Parse other_tags
     def parse_tags(tags):
+        """Safe parser for OSM tags in JSON or HSTORE-like format."""
         if not tags or tags == "nan":
             return {}
+
+        # Limit string length to prevent resource exhaustion
+        if len(tags) > 100000:
+            return {}
+
+        # 1. Try JSON format
         try:
-            return ast.literal_eval(tags)
-        except (ValueError, SyntaxError):
+            return json.loads(tags)
+        except (json.JSONDecodeError, RecursionError):
+            pass
+
+        # 2. Try HSTORE-like format: "key"=>"value", "key2"=>"value2"
+        d = {}
+        try:
+            # This regex matches "key"=>"value" pairs, handles backslash-escaped quotes
+            pattern = r'"((?:\\.|[^"\\])*)"\s*=>\s*"((?:\\.|[^"\\])*)"'
+            for match in re.finditer(pattern, tags):
+                key = match.group(1).replace('\\"', '"').replace('\\\\', '\\')
+                value = match.group(2).replace('\\"', '"').replace('\\\\', '\\')
+                d[key] = value
+            return d
+        except Exception:
             return {}
 
     if "other_tags" in gdf.columns:


### PR DESCRIPTION
The `parse_tags` function in `headless_sidewalkreator/generic_functions.py` used `ast.literal_eval` to process OSM tags. This was vulnerable to DoS attacks using deeply nested input and lacked support for the HSTORE format. This PR replaces it with a safer, length-limited parser that handles both JSON and HSTORE formats.

---
*PR created automatically by Jules for task [16243826079941421635](https://jules.google.com/task/16243826079941421635) started by @kauevestena*