### PR TITLE
🧪 Add edge case tests for split_sidewalks_by_max_length

### DIFF
--- a/test/test_generic_functions.py
+++ b/test/test_generic_functions.py
@@ -208,6 +208,38 @@ def test_split_sidewalks_by_max_length():
     splitted_gdf = split_sidewalks_by_max_length(sidewalks_gdf, max_length=2)
     assert len(splitted_gdf) == 5
 
+def test_split_sidewalks_by_max_length_short_line():
+    """Test split_sidewalks_by_max_length with a line shorter than max_length."""
+    line = LineString([(0,0), (5,0)])
+    sidewalks_gdf = gpd.GeoDataFrame(geometry=[line], crs="EPSG:3857")
+
+    splitted_gdf = split_sidewalks_by_max_length(sidewalks_gdf, max_length=10)
+    assert len(splitted_gdf) == 1
+    assert splitted_gdf.geometry.iloc[0].equals(line)
+
+def test_split_sidewalks_by_max_length_large_max_length():
+    """Test split_sidewalks_by_max_length with an extremely large max_length."""
+    line = LineString([(0,0), (10,0)])
+    sidewalks_gdf = gpd.GeoDataFrame(geometry=[line], crs="EPSG:3857")
+
+    splitted_gdf = split_sidewalks_by_max_length(sidewalks_gdf, max_length=1e9)
+    assert len(splitted_gdf) == 1
+    assert splitted_gdf.geometry.iloc[0].equals(line)
+
+def test_split_sidewalks_by_max_length_invalid_geometry():
+    """Test split_sidewalks_by_max_length with invalid geometry."""
+    sidewalks_gdf = gpd.GeoDataFrame(geometry=[Point(0, 0)], crs="EPSG:3857")
+
+    splitted_gdf = split_sidewalks_by_max_length(sidewalks_gdf, max_length=10)
+    assert len(splitted_gdf) == 1
+
+def test_split_sidewalks_by_max_length_empty_input():
+    """Test split_sidewalks_by_max_length with empty GeoDataFrame."""
+    sidewalks_gdf = gpd.GeoDataFrame(geometry=[], crs="EPSG:3857")
+
+    splitted_gdf = split_sidewalks_by_max_length(sidewalks_gdf, max_length=10)
+    assert splitted_gdf.empty
+
 def test_split_sidewalks_by_num_segments():
     """Test split_sidewalks_by_num_segments."""
     line = LineString([(0,0), (10,0)])


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was missing edge case tests for the `split_sidewalks_by_max_length` function in `generic_functions.py`. Specifically, it lacked coverage for linestrings shorter than the `max_length` threshold and other edge cases like very large maximum lengths.

📊 **Coverage:** The scenarios now tested include:
- A valid linestring shorter than the `max_length`, ensuring it remains unchanged.
- An extremely large `max_length` value (`1e9`), verifying it returns the original linestring.
- Invalid geometries (e.g., points).
- Empty GeoDataFrames.

✨ **Result:** The improvement in test coverage guarantees that `split_sidewalks_by_max_length` behaves safely and predictably for edge-case inputs. The tests correctly assert that geometries are returned intact without errors or unnecessary modifications.

---
*PR created automatically by Jules for task [1681310284116526259](https://jules.google.com/task/1681310284116526259) started by @kauevestena*