### PR TITLE
🧹 Remove unused and redundant imports in generic_functions.py

### DIFF
--- a/headless_sidewalkreator/generic_functions.py
+++ b/headless_sidewalkreator/generic_functions.py
@@ -9,11 +9,9 @@ import math
 import geopandas as gpd
 from typing import Optional
 from shapely.geometry import (
-    GeometryCollection,
     LineString,
     MultiLineString,
     MultiPoint,
-    MultiPolygon,
     Point,
     Polygon,
 )
@@ -163,8 +161,6 @@ def fetch_street_network_for_bbox(bbox: tuple, timeout: int = 60) -> gpd.GeoData
             minx, miny, maxx, maxy = arr
 
         # Create a small cross network and one extra branch
-        from shapely.geometry import LineString
-
         lines = [
             LineString([(minx, miny), (maxx, maxy)]),
             LineString([(minx, maxy), (maxx, miny)]),
@@ -240,8 +236,6 @@ def polygonize_lines_gdf(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
         # rings when endpoints are nearly identical but have tiny floating
         # differences. Round to 6 decimal places which is sufficient for our
         # test fixtures and typical projected coordinates.
-        from shapely.geometry import LineString
-
         snapped_lines = []
         for ln in lines:
             if ln is None or ln.is_empty:
@@ -288,7 +282,6 @@ import re
 import pandas as pd
 
 from shapely.ops import split, substring
-from shapely.geometry import MultiPoint, Point
 
 
 def split_lines_at_intersections(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
@@ -549,9 +542,6 @@ def calculate_tangent_direction(
     if length < 1e-6:
         return (1.0, 0.0)  # default fallback
     return (dx / length, dy / length)
-
-
-import networkx as nx
 
 
 def remove_lines_from_no_block_gdf(
@@ -1469,8 +1459,6 @@ def split_sidewalks_by_protoblock_corners(
             if len(boundaries) == 1:
                 sidewalk = boundaries[0]
             else:
-                from shapely.geometry import MultiLineString
-
                 sidewalk = MultiLineString(boundaries)
 
         # Now handle LineString and MultiLineString
@@ -1503,8 +1491,6 @@ def split_sidewalks_by_protoblock_corners(
                     new_sidewalks.append(sidewalk)
         else:
             # For unsupported geometry types (Point, etc.), return empty geometry
-            from shapely.geometry import Point
-
             if sidewalk.geom_type in ["Point", "MultiPoint"]:
                 new_sidewalks.append(Point().boundary)  # Empty geometry
             else:


### PR DESCRIPTION
🎯 **What:**
- Removed unused imports: `MultiPolygon`, `GeometryCollection`, and `networkx`.
- Consolidated redundant local imports of `LineString`, `MultiLineString`, `Point`, and `MultiPoint` from functions into the module's top-level import block.
- Removed duplicate module-level imports of `Point` and `MultiPoint`.

💡 **Why:**
Unused and redundant imports clutter the code, increase cognitive load for maintainers, and can lead to confusion. Consolidating imports at the top level is a Pythonic practice that improves readability and maintainability.

✅ **Verification:**
- Verified syntax correctness using `ast.parse`.
- Confirmed that all remaining references to `MultiPolygon` and `GeometryCollection` are string literals for `geom_type` checks, which do not require importing the classes.
- Verified that the consolidated imports are correctly used throughout the file.
- Ran test suite (with limitations due to environment-specific geospatial dependency issues).

✨ **Result:**
A cleaner, more maintainable `generic_functions.py` file with improved readability and adherence to standard Python import conventions.

---
*PR created automatically by Jules for task [2992283277156473660](https://jules.google.com/task/2992283277156473660) started by @kauevestena*