### PR TITLE
🧹 [code health] Remove unused exception variables in generic_functions.py

### DIFF
--- a/headless_sidewalkreator/generic_functions.py
+++ b/headless_sidewalkreator/generic_functions.py
@@ -1339,7 +1339,7 @@ def split_sidewalks_by_voronoi(
 
     try:
         vor = Voronoi(points)
-    except Exception as e:
+    except Exception:
         # Voronoi computation failed, return original sidewalks
         return sidewalks_gdf
 
@@ -1350,7 +1350,7 @@ def split_sidewalks_by_voronoi(
             for line in vor.ridge_vertices
             if -1 not in line
         ]
-    except Exception as e:
+    except Exception:
         return sidewalks_gdf
 
     if not lines:
@@ -1392,7 +1392,7 @@ def split_sidewalks_by_voronoi(
                     # Successfully split - use the split result for next iteration
                     splittable_geom = split_result
                     break
-            except Exception as e:
+            except Exception:
                 # Split failed, but continue with other lines
                 continue
 
@@ -1566,7 +1566,7 @@ def split_sidewalks_by_max_length(
                         new_sidewalks.append(new_sidewalk_parts)
                 else:
                     new_sidewalks.append(sidewalk)
-            except Exception as e:
+            except Exception:
                 # If splitting fails, keep the original geometry
                 new_sidewalks.append(sidewalk)
         else:


### PR DESCRIPTION
🎯 **What:**
Removed four instances of unused exception variables (`e`) in `try/except` blocks within `headless_sidewalkreator/generic_functions.py`.

💡 **Why:**
The exception objects were neither logged nor examined. Using `except Exception:` instead of `except Exception as e:` improves maintainability by removing dead variables and silencing potential linting warnings about unused variables.

✅ **Verification:**
- Performed syntax validation using `python3 -c "import ast; ast.parse(...)"`.
- Verified the removal of the specific pattern using `grep`.
- Confirmed no other instances of unused exception variables exist in the target file.
- The change is a non-functional refactoring that preserves all existing error-handling logic.

✨ **Result:**
Cleaner code that adheres to Python best practices for ignoring exception objects.

---
*PR created automatically by Jules for task [4004487665186817762](https://jules.google.com/task/4004487665186817762) started by @kauevestena*