### PR TITLE
🧪 [testing improvement] Add unit tests for reproject_gdf

### DIFF
--- a/test/test_generic_functions.py
+++ b/test/test_generic_functions.py
@@ -1,6 +1,10 @@
 import math
+from pyproj.exceptions import CRSError
 import pytest
 import geopandas as gpd
+
+
+
 from shapely.geometry import LineString, Polygon, Point
 from unittest.mock import patch, MagicMock
 
@@ -24,6 +28,7 @@ from headless_sidewalkreator.generic_functions import (
     bbox_to_gdf,
     calculate_tangent_direction,
     calculate_sidewalk_properties,
+    reproject_gdf,
 )
 from headless_sidewalkreator.parameters import default_widths, fallback_default_width
 
@@ -495,3 +500,43 @@ def test_calculate_sidewalk_properties_point():
 
     assert result_gdf["area"].iloc[0] == 0.0
     assert result_gdf["perimeter"].iloc[0] == 0.0
+
+
+
+
+
+def test_reproject_gdf_happy_path():
+    """Test reprojecting a GeoDataFrame from EPSG:4326 to EPSG:3857."""
+    gdf = gpd.GeoDataFrame({"geometry": [Point(1, 1)]}, crs="EPSG:4326")
+    reprojected_gdf = reproject_gdf(gdf, "EPSG:3857")
+
+    assert reprojected_gdf.crs.to_string() == "EPSG:3857"
+    assert len(reprojected_gdf) == 1
+
+    # 1,1 in 4326 is approx 111319.49, 111325.14 in 3857
+    point = reprojected_gdf.geometry.iloc[0]
+    assert point.x == pytest.approx(111319.49, rel=1e-5)
+    assert point.y == pytest.approx(111325.14, rel=1e-5)
+
+def test_reproject_gdf_empty():
+    """Test reprojecting an empty GeoDataFrame."""
+    gdf = gpd.GeoDataFrame({"geometry": []}, crs="EPSG:4326")
+    reprojected_gdf = reproject_gdf(gdf, "EPSG:3857")
+
+    assert reprojected_gdf.empty
+    assert reprojected_gdf.crs.to_string() == "EPSG:3857"
+
+def test_reproject_gdf_same_crs():
+    """Test reprojecting to the same CRS."""
+    gdf = gpd.GeoDataFrame({"geometry": [Point(1, 1)]}, crs="EPSG:4326")
+    reprojected_gdf = reproject_gdf(gdf, "EPSG:4326")
+
+    assert reprojected_gdf.crs.to_string() == "EPSG:4326"
+    assert reprojected_gdf.geometry.iloc[0].x == 1.0
+    assert reprojected_gdf.geometry.iloc[0].y == 1.0
+
+def test_reproject_gdf_invalid_crs():
+    """Test reprojecting with an invalid CRS raises CRSError."""
+    gdf = gpd.GeoDataFrame({"geometry": [Point(1, 1)]}, crs="EPSG:4326")
+    with pytest.raises(CRSError):
+        reproject_gdf(gdf, "INVALID_CRS")


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was missing coverage for the `reproject_gdf` function in `headless_sidewalkreator/generic_functions.py`.
📊 **Coverage:** What scenarios are now tested:
- Happy path for reprojecting EPSG:4326 point data to EPSG:3857, verified with `pytest.approx` coordinate mapping.
- Graceful handling of empty GeoDataFrames with a valid target CRS.
- Reprojecting to the identical target CRS with no data mutations.
- Appropriate validation expecting `pyproj.exceptions.CRSError` when given an invalid target CRS string.
✨ **Result:** The improvement in test coverage provides a safety net ensuring CRS conversion behavior works reliably for valid data while accurately failing fast on bad configurations without swallowing exceptions.

---
*PR created automatically by Jules for task [6347644537870609670](https://jules.google.com/task/6347644537870609670) started by @kauevestena*