### PR TITLE
🧹 [code health improvement] Update outdated README and setup instructions

### DIFF
--- a/.github/copilot-setup-steps.yml
+++ b/.github/copilot-setup-steps.yml
@@ -8,13 +8,8 @@ steps:
   - name: Install Python dependencies
     run: |
       python -m pip install --upgrade pip setuptools wheel
-      pip install -r requirements-runtime.txt
-      pip install -r requirements-dev.txt
+      pip install -e .[dev]
     description: Install all runtime and development dependencies using pip
-
-  - name: Install package in editable mode
-    run: pip install -e .
-    description: Install the package in development mode for testing
 
   - name: Run tests to verify setup
     run: pytest -q
@@ -30,8 +25,8 @@ notes: |
   ## Running the tool
   After setup, you can import and use the main function:
   ```python
-  from headless_sidewalkreator import run_headless
-  run_headless("input_polygon.geojson", "output_dir")
+  from headless_sidewalkreator import sidewalkreator
+  result = sidewalkreator(place_name="Amherst, MA")
   ```
 
   ## Understanding the algorithm

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ python3 -m venv .venv
 source .venv/bin/activate
 
 # upgrade pip and build tools
-pip install --upgrade pip setuptools wheel
+python -m pip install --upgrade pip setuptools wheel
 ```
 
 2. Install all dependencies:
@@ -146,7 +146,7 @@ To install the package in editable/development mode:
 pip install -e .
 
 # then you can import the package in Python
-python -c "from headless_sidewalkreator import run_headless; print(run_headless.__doc__)"
+python -c "from headless_sidewalkreator import sidewalkreator; print(sidewalkreator.__doc__)"
 ```
 
 ## Notes
@@ -162,4 +162,3 @@ these steps.
 This is the headless version of a QGIS Plugin called OSM Sidewalkreator, available at:
 
 https://github.com/kauevestena/osm_sidewalkreator
-


### PR DESCRIPTION
🎯 **What:**
- Replaced outdated `run_headless` references with `sidewalkreator` in README and setup instructions.
- Updated dependency installation instructions to use `pip install -e .[dev]` instead of missing requirements files.
- Replaced direct `pip` call with `python -m pip` to follow best practices for virtual environments.

💡 **Why:**
- The README and GitHub copilot setup steps referenced old, deprecated APIs and non-existent `requirements.txt` files, which could cause confusion and prevent a successful environment setup.

✅ **Verification:**
- Verified that all documentation files specify correct Python imports.
- Verified that `pip install -e .[dev]` successfully installs dependencies.
- Pytest suite executes successfully.

✨ **Result:**
- README and configuration files now accurately describe project setup and usage.

---
*PR created automatically by Jules for task [3646302647962142311](https://jules.google.com/task/3646302647962142311) started by @kauevestena*