### PR TITLE
🧹 [remove unused annotations import]

### DIFF
--- a/headless_sidewalkreator/logging_config.py
+++ b/headless_sidewalkreator/logging_config.py
@@ -1,7 +1,5 @@
 """Centralised logging configuration for the headless_sidewalkreator package."""
 
-from __future__ import annotations
-
 import logging
 from typing import Optional
 


### PR DESCRIPTION
🎯 **What:**
Removed the unused `from __future__ import annotations` import from `headless_sidewalkreator/logging_config.py`.

💡 **Why:**
The `annotations` future import was not being utilized as there are no forward references in the type hints within this module. Removing it improves code health by eliminating dead code and reducing unnecessary complexity.

✅ **Verification:**
- Manually inspected `headless_sidewalkreator/logging_config.py` to confirm no forward references exist.
- Ran the full test suite using `pytest`, which passed with 85 passed, 2 skipped, and 1 xfailed (consistent with the baseline).

✨ **Result:**
Improved maintainability and readability of `headless_sidewalkreator/logging_config.py` by removing an unused import.

---
*PR created automatically by Jules for task [4565326091099217163](https://jules.google.com/task/4565326091099217163) started by @kauevestena*