### PR TITLE
🔒 Fix NaN road_width handling in sidewalk generation

### DIFF
--- a/debug/benchmark_buffering.py
+++ b/debug/benchmark_buffering.py
@@ -26,7 +26,10 @@ def optimized_approach(streets_gdf):
     sure_streets = streets_gdf[streets_gdf["sidewalk"].isin(["yes", "both"])]
     if not sure_streets.empty:
         # Vectorized buffer
-        road_widths = pd.to_numeric(sure_streets.get("width", 6.0), errors="coerce").fillna(6.0)
+        if "width" in sure_streets.columns:
+            road_widths = pd.to_numeric(sure_streets["width"], errors="coerce").fillna(6.0)
+        else:
+            road_widths = 6.0
         buffer_distances = (road_widths / 2) + 1.0
         sure_geometries.extend(sure_streets.geometry.buffer(buffer_distances).tolist())
     return sure_geometries

--- a/headless_sidewalkreator/generic_functions.py
+++ b/headless_sidewalkreator/generic_functions.py
@@ -445,7 +445,9 @@ def adjust_buffer_for_buildings(
         line = row.geometry
 
         # Get road width if available, otherwise use sensible default
-        road_width = row.get("width", 6.0)  # Default 6m road width
+        road_width = row.get("width", 6.0)
+        if pd.isna(road_width) or road_width <= 0:
+            road_width = 6.0
 
         # Find potential building matches using spatial index with expanded bounds
         # Expand line bounds by default buffer distance to catch nearby buildings
@@ -520,7 +522,10 @@ def handle_sidewalk_tags(
     no_sidewalk_streets = streets_gdf[streets_gdf["sidewalk"] == "no"]
     if not no_sidewalk_streets.empty:
         # Vectorized buffer: road_width/2 + 1.0
-        road_widths = no_sidewalk_streets.get("width", 6.0)
+        if "width" in no_sidewalk_streets.columns:
+            road_widths = pd.to_numeric(no_sidewalk_streets["width"], errors="coerce").fillna(6.0)
+        else:
+            road_widths = 6.0
         buffer_distances = (road_widths / 2) + 1.0
         exclusion_geometries.extend(
             no_sidewalk_streets.geometry.buffer(buffer_distances)
@@ -531,7 +536,10 @@ def handle_sidewalk_tags(
         side_streets = streets_gdf[streets_gdf["sidewalk"] == side]
         if not side_streets.empty:
             # Vectorized offset and buffer
-            road_widths = side_streets.get("width", 6.0)
+            if "width" in side_streets.columns:
+                road_widths = pd.to_numeric(side_streets["width"], errors="coerce").fillna(6.0)
+            else:
+                road_widths = 6.0
             buffer_distances = road_widths / 2
             offset_lines = side_streets.geometry.offset_curve(
                 buffer_distances if side == "left" else -buffer_distances, join_style=2
@@ -834,7 +842,7 @@ class _CrossingsGenerator:
             value = float(value)
         except (TypeError, ValueError):
             value = self.fallback_width
-        if value <= 0:
+        if pd.isna(value) or value <= 0:
             value = self.fallback_width
         return value
 
@@ -857,7 +865,7 @@ class _CrossingsGenerator:
             value = float(value)
         except (TypeError, ValueError):
             value = self.fallback_width
-        if value <= 0:
+        if pd.isna(value) or value <= 0:
             value = self.fallback_width
         return value
 

--- a/test/test_generic_functions.py
+++ b/test/test_generic_functions.py
@@ -589,3 +589,35 @@ def test_clean_geometries_gdf():
     # and snapped to 0.1 (coordinates are already integers, so unchanged by snapping)
     assert len(geoms[2].exterior.coords) == 5
     assert (1.0, 0.0) not in list(geoms[2].exterior.coords)
+
+def test_resolve_width_namedtuple_with_nan():
+    from headless_sidewalkreator.generic_functions import _CrossingsGenerator
+    from collections import namedtuple
+    import pandas as pd
+    import numpy as np
+
+    generator = _CrossingsGenerator()
+    generator.fallback_width = 6.0
+
+    Row = namedtuple("Row", ["width"])
+
+    # Test with NaN
+    row_nan = Row(width=np.nan)
+    assert generator._resolve_width_namedtuple(row_nan) == 6.0
+
+    # Test with None
+    row_none = Row(width=None)
+    assert generator._resolve_width_namedtuple(row_none) == 6.0
+
+    # Test with valid width
+    row_valid = Row(width=8.0)
+    assert generator._resolve_width_namedtuple(row_valid) == 8.0
+
+    # Test with non-numeric
+    row_str = Row(width="invalid")
+    assert generator._resolve_width_namedtuple(row_str) == 6.0
+
+    # Test missing width (getattr default)
+    RowNoWidth = namedtuple("RowNoWidth", ["other"])
+    row_no_width = RowNoWidth(other=1)
+    assert generator._resolve_width_namedtuple(row_no_width) == 6.0


### PR DESCRIPTION
🎯 **What:** Robustly handle `NaN` and missing values for `road_width` in both iterative and vectorized code paths within the sidewalk generation algorithm.

⚠️ **Risk:** The algorithm could crash or produce incorrect buffer/offset geometries when processing OSM data that contains missing width attributes or explicit `NaN` values, as `getattr` or simple defaults do not catch `NaN` in Pandas/GeoPandas.

🛡️ **Solution:** 
- Updated `_resolve_width`, `_resolve_width_namedtuple`, and `get_adjusted_buffer` in `headless_sidewalkreator/generic_functions.py` to explicitly check for `NaN` using `pd.isna()`.
- Refactored vectorized road width resolution (for `sidewalk=no/left/right` cases) to safely handle missing or non-numeric "width" columns using `pd.to_numeric` with `fillna`.
- Updated the benchmark script `debug/benchmark_buffering.py` to reflect these robust patterns.
- Added a new test suite `test_resolve_width_namedtuple_with_nan` in `test/test_generic_functions.py` covering various edge cases.

---
*PR created automatically by Jules for task [3504638046440792460](https://jules.google.com/task/3504638046440792460) started by @kauevestena*